### PR TITLE
Potential fix for code scanning alert no. 15: Potentially unsafe quoting

### DIFF
--- a/src/arm/locals.go
+++ b/src/arm/locals.go
@@ -1,6 +1,7 @@
 package arm
 
 import (
+	"strconv"
 	"strings"
 )
 
@@ -30,7 +31,7 @@ func ParseLocals(result map[string]interface{}) (string, map[string]interface{},
 		myLocals[item] = theValue
 
 		if strings.Contains(theValue, "${") {
-			local = "\t" + item + " = \"" + theValue + "\" #" + original + "\n"
+			local = "\t" + item + " = " + strconv.Quote(theValue) + " #" + original + "\n"
 		} else {
 			local = "\t" + item + " = " + theValue + " #" + original + "\n"
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/JamesWoolfenden/sato/security/code-scanning/15](https://github.com/JamesWoolfenden/sato/security/code-scanning/15)

The best fix is to stop manually embedding untrusted text into quoted literals and instead escape it using a safe quoting API. In Go, `strconv.Quote` is ideal here because it returns a valid double-quoted string literal with required escaping (including `"` and `\`).

In `src/arm/locals.go`, update the quoted branch in `ParseLocals` to build:

- `... = ` + `strconv.Quote(theValue)` + ` ...`

instead of `... = "` + theValue + `"`.

This preserves existing behavior (still emits quoted literal) while preventing quote-breaking. Keep the unquoted branch unchanged to avoid functionality drift. Add `strconv` import. No new helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
